### PR TITLE
Feature/context menu

### DIFF
--- a/Shared/Data/AppData.swift
+++ b/Shared/Data/AppData.swift
@@ -77,6 +77,10 @@ class AppData {
         }
     }
     
+    static func refreshFeed(_ feed: Feed, completion: (()->Void)? ) {
+        feed.load(completion: completion)
+    }
+    
     static func refreshFeeds(rowCompletion: (()->Void)? ) {
         for feed in AppData.shared.feeds {
             feed.load(completion: rowCompletion)

--- a/Super Simple RSS/UI/Feeds/FeedsViewController.swift
+++ b/Super Simple RSS/UI/Feeds/FeedsViewController.swift
@@ -236,6 +236,12 @@ extension FeedsViewController: UITableViewDelegate {
         
         let configuration = UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [unowned self] (menuElement) -> UIMenu? in
             
+            let refresh = UIAction(title: "Refresh", image: UIImage(systemName: "arrow.clockwise")) { (action) in
+                AppData.refreshFeed(feed) {
+                    applySnapshot()
+                }
+            }
+            
             let edit = UIAction(title: "Edit", image: UIImage(systemName: "pencil")) { (action) in
                 
                 let alert = UIAlertController(title: "Edit Feed", message: "Feed URL?", preferredStyle: .alert)
@@ -274,7 +280,10 @@ extension FeedsViewController: UITableViewDelegate {
                 self.applySnapshot()
             }
             
-            return UIMenu(title: "", image: nil, children: [edit, delete])
+            
+            let modifiers = UIMenu(title: "", image: nil, options: .displayInline, children: [edit, delete])
+            
+            return UIMenu(title: "", image: nil, children: [refresh, modifiers])
         }
         
         return configuration

--- a/Super Simple RSS/UI/Feeds/FeedsViewController.swift
+++ b/Super Simple RSS/UI/Feeds/FeedsViewController.swift
@@ -276,8 +276,19 @@ extension FeedsViewController: UITableViewDelegate {
             
             let delete = UIAction(title: "Delete", image: UIImage(systemName: "trash")) { [unowned self] (action) in
                 
-                AppData.deleteFeed(feed)
-                self.applySnapshot()
+                let alert = UIAlertController(title: "Delete \(feed.name ?? feed.url.absoluteString)?", message: "This action cannot be undone", preferredStyle: .alert)
+                
+                
+                alert.addAction(UIAlertAction(title: "Cancel", style: .default, handler: { action in
+                    alert.dismiss(animated: true, completion: nil)
+                }))
+                
+                alert.addAction(UIAlertAction(title: "Delete", style: .destructive, handler: { action in
+                    AppData.deleteFeed(feed)
+                    self.applySnapshot()
+                }))
+                
+                self.navigationController?.present(alert, animated: true, completion: nil)
             }
             
             


### PR DESCRIPTION
Add a context menu to iOS and Catalyst apps. This should address and close issue #2 (finally! 🙂)

![Simulator Screen Shot - iPhone 12 - 2021-01-04 at 21 44 08](https://user-images.githubusercontent.com/354758/103607374-fb891e00-4ed5-11eb-9100-998cb94213ad.png)

<img width="469" alt="Screen Shot 2021-01-04 at 9 41 10 PM" src="https://user-images.githubusercontent.com/354758/103607380-fe840e80-4ed5-11eb-918e-e11fcec3e437.png">
